### PR TITLE
Add MuMu Player support as an alternative emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@
     * Add to system path
         * Verify with: `adb --version`
 2. An Android emulator — either [BlueStacks](https://www.bluestacks.com/) or [MuMu Player](https://www.mumuplayer.com/) (set `EMULATOR_TYPE` accordingly in `configs.py`)
-    * Device profile: Samsung Galaxy S22 Ultra
-    * Display resolution: 1920 x 1080
-    * Frame rate: 60 (__NOTE__: Inconsistent touch events at lower fps)
-    * Install Clash of Clans from Google Play
-        * Default troop deployment size
-        * Standard or XL scenery
+    * The specs below apply to whichever emulator you choose:
+        * Device profile: Samsung Galaxy S22 Ultra
+        * Display resolution: 1920 x 1080
+        * Frame rate: 60 (__NOTE__: Inconsistent touch events at lower fps)
+        * Install Clash of Clans from Google Play
+            * Default troop deployment size
+            * Standard or XL scenery
 
     __If using BlueStacks:__
     * Enable Android Debug Bridge in "Advanced" settings
@@ -44,7 +45,7 @@
     __If using MuMu Player:__
     * In MuMu's multi-instance manager, rename instances to match instance IDs in `configs.py` (same convention as BlueStacks above)
     * The bot drives MuMu through its official `MuMuManager.exe` CLI (found under `<MuMu install dir>/nx_main/MuMuManager.exe`); if it's not auto-detected, set `MUMU_BIN_PATH` in `configs.py`
-    * Windows only — MuMu Player support has not been tested on other platforms
+    * Windows only — MuMu Player support relies on `MuMuManager.exe`
 
 ## Default Setup Instructions
 1. Install and configure [external dependencies](#dependencies)

--- a/README.md
+++ b/README.md
@@ -23,21 +23,28 @@
 * iPhone shortcut to auto resume / pause bot when CoC is opened by user ⏯️
 * Telegram and web app notifications 🔔
 * Automatic CoC app updates 🔼
-* Automatic BlueStacks instance launch / shutdown 🔌
+* Automatic emulator instance launch / shutdown (BlueStacks or MuMu Player) 🔌
 
 ## Dependencies
 1. [Android Debug Bridge](https://developer.android.com/tools/releases/platform-tools)
     * Add to system path
         * Verify with: `adb --version`
-2. [BlueStacks](https://www.bluestacks.com/)
+2. An Android emulator — either [BlueStacks](https://www.bluestacks.com/) or [MuMu Player](https://www.mumuplayer.com/) (set `EMULATOR_TYPE` accordingly in `configs.py`)
     * Device profile: Samsung Galaxy S22 Ultra
     * Display resolution: 1920 x 1080
     * Frame rate: 60 (__NOTE__: Inconsistent touch events at lower fps)
-    * Enable Android Debug Bridge in "Advanced" settings
-    * In Multi-Instance Manager, rename instances to match instance IDs in `configs.py` (the default ID is main, see steps 3 and 6 in [Custom Setup Instructions](#custom-setup-instructions-recommended) for more details)
     * Install Clash of Clans from Google Play
         * Default troop deployment size
         * Standard or XL scenery
+
+    __If using BlueStacks:__
+    * Enable Android Debug Bridge in "Advanced" settings
+    * In Multi-Instance Manager, rename instances to match instance IDs in `configs.py` (the default ID is main, see steps 3 and 6 in [Custom Setup Instructions](#custom-setup-instructions-recommended) for more details)
+
+    __If using MuMu Player:__
+    * In MuMu's multi-instance manager, rename instances to match instance IDs in `configs.py` (same convention as BlueStacks above)
+    * The bot drives MuMu through its official `MuMuManager.exe` CLI (found under `<MuMu install dir>/nx_main/MuMuManager.exe`); if it's not auto-detected, set `MUMU_BIN_PATH` in `configs.py`
+    * Windows only — MuMu Player support has not been tested on other platforms
 
 ## Default Setup Instructions
 1. Install and configure [external dependencies](#dependencies)
@@ -88,15 +95,15 @@
     * Create an Automation task that runs when CoC opens and is set to run immediately
 
 1. Start the bot: `python src/main.py`
-    > ❗️ __Important__: By default, the bot is configured to start and stop its BlueStacks instance automatically. If this behavior is undesired or causing issues, just set `AUTO_START_BLUESTACKS = False` in `configs.py`
+    > ❗️ __Important__: By default, the bot is configured to start and stop its emulator instance automatically. If this behavior is undesired or causing issues, just set `AUTO_START_EMULATOR = False` in `configs.py`
 
     > __Note__: On MacOS, if `DISABLE_DEVICE_SLEEP = True` in `configs.py`, the user password is required to toggle the `disablesleep` flag in power management settings
 
-    > 💡 __Tip__: The BlueStacks window can be minimized without disrupting the bot as all interactions are handled through Android Debug Bridge
+    > 💡 __Tip__: The emulator window can be minimized without disrupting the bot as all interactions are handled through Android Debug Bridge
 
     > 💡 __Tip__: If not using the bot for development purposes, it can be built into an executable or desktop app for convenience using [build.sh](scripts/build.sh). The desktop app GUI or command-line arguments can be used to specify the instance to run if using multiple bot instances. View a demo of the desktop app [here](#desktop-app-demo).
 
-    * To run bots for multiple accounts just create additional BlueStacks instances with BlueStacks' multi-instance manager (ensuring BlueStacks instance names match bot instance IDs), set up the instance as usual, and append new instance names to `INSTANCE_IDS` in `configs.py`. Specify the instance to run using the `--id` flag (e.g. `python src/main.py --id main`).
+    * To run bots for multiple accounts just create additional instances with your emulator's multi-instance manager (ensuring instance names match bot instance IDs), set up the instance as usual, and append new instance names to `INSTANCE_IDS` in `configs.py`. Specify the instance to run using the `--id` flag (e.g. `python src/main.py --id main`).
 
 ## Miscellaneous
 * Please report issues in the [Issues Tab](https://github.com/m24842/CoC_Bot/issues)

--- a/src/attacker.py
+++ b/src/attacker.py
@@ -10,31 +10,7 @@ class Attacker:
     def __init__(self):
         self.assets = Asset_Manager.attacker_assets
         self.misc_assets = Asset_Manager.misc_assets
-        self._debug_attack_step = 0
 
-    def _debug_stage(self, name):
-        """Save a labeled full-screen snapshot for the home-base attack flow."""
-        if not configs.DEBUG:
-            return
-
-        from pathlib import Path
-        import cv2
-
-        self._debug_attack_step += 1
-        frame = Frame_Handler.get_frame(grayscale=False)
-        frame = frame.copy()
-        label = f"HOME ATTACK {self._debug_attack_step:02d}: {name}"
-        cv2.putText(frame, label, (16, 34), cv2.FONT_HERSHEY_SIMPLEX,
-                    0.8, (0, 255, 0), 2, cv2.LINE_AA)
-        Path("debug").mkdir(exist_ok=True)
-        Frame_Handler.save_frame(
-            frame,
-            f"debug/attack_{self._debug_attack_step:02d}_{name}.png",
-        )
-        Path("debug/attack_flow.log").open("a", encoding="utf-8").write(
-            label + "\n"
-        )
-    
     # ============================================================
     # 📱 Screen Interaction
     # ============================================================
@@ -66,13 +42,9 @@ class Attacker:
     def start_normal_attack(self, timeout=60):
         import time
 
-        self._debug_attack_step = 0
-        self._debug_stage("01_before_attack")
-
         # Click attack
         Input_Handler.click(0.07, 0.9)
-        self._debug_stage("02_attack_menu")
-        
+
         # Find a match
         def locate_find_a_match():
             xys = Frame_Handler.locate(self.assets["find_a_match"], thresh=0.9, return_all=True)
@@ -85,29 +57,20 @@ class Attacker:
         if not click_with_timeout(
             locate_find_a_match,
             timeout=5
-        ):
-            self._debug_stage("03_find_match_not_found")
-            return False
-        self._debug_stage("03_find_match")
-        
+        ): return False
+
         # Confirm attack
         if not click_with_timeout(
             lambda: Frame_Handler.locate(self.assets["confirm_attack"], thresh=0.9),
             timeout=5
-        ):
-            self._debug_stage("04_confirm_not_found")
-            return False
-        self._debug_stage("04_confirmed")
-        
+        ): return False
+
         # Wait until "end battle" button is found
         start_time = time.time()
         while time.time() - start_time < timeout:
             x, y = Frame_Handler.locate(self.assets["end_battle"], thresh=0.9)
-            if x is not None and y is not None:
-                self._debug_stage("05_battle_started")
-                return True
+            if x is not None and y is not None: return True
             time.sleep(0.1)
-        self._debug_stage("05_battle_timeout")
         return False
     
     def start_builder_attack(self, timeout=60):
@@ -285,7 +248,6 @@ class Attacker:
     def complete_normal_attack(self, restart=True, exclude_clan_troops=False):
         import time, numpy as np
 
-        self._debug_stage("06_battle_before_troops")
         Input_Handler.zoom(dir="out")
         Input_Handler.swipe_up()
         
@@ -298,8 +260,6 @@ class Attacker:
             # Find troops to deploy
             card_centers, card_boundaries, card_types, card_counts, type_gaps_seen = self.detect_troop_positions(frame, clip_left=last_card_left, type_gaps_seen=type_gaps_seen, return_boundaries=True, return_types=True, return_counts=True)
 
-            self._debug_stage(f"07_troop_cards_{total_slots_seen}")
-            
             if len(card_centers) == 0: break
 
             # Exclude clan troops if specified
@@ -315,7 +275,6 @@ class Attacker:
             # Deploy troops up until the last one visible
             total_slots_seen += len(card_centers) - 1
             self.deploy_troops(card_centers[:-1], available_slots[:-1], card_types[:-1], card_counts[:-1])
-            self._debug_stage(f"08_deployed_{total_slots_seen}")
             # Scroll over and look for the new position of the last card
             last_card_frame = frame[:, int(card_boundaries[-2] * frame.shape[1]):int(card_boundaries[-1] * frame.shape[1])]
             Input_Handler.swipe_left(x1=card_centers[-1], x2=0.038, y=0.9, hold_end_time=500)
@@ -330,7 +289,6 @@ class Attacker:
                 break
         
         # Close and reopen CoC to auto complete battle
-        self._debug_stage("09_battle_complete")
         if restart:
             start_coc()
         else:

--- a/src/attacker.py
+++ b/src/attacker.py
@@ -10,6 +10,30 @@ class Attacker:
     def __init__(self):
         self.assets = Asset_Manager.attacker_assets
         self.misc_assets = Asset_Manager.misc_assets
+        self._debug_attack_step = 0
+
+    def _debug_stage(self, name):
+        """Save a labeled full-screen snapshot for the home-base attack flow."""
+        if not configs.DEBUG:
+            return
+
+        from pathlib import Path
+        import cv2
+
+        self._debug_attack_step += 1
+        frame = Frame_Handler.get_frame(grayscale=False)
+        frame = frame.copy()
+        label = f"HOME ATTACK {self._debug_attack_step:02d}: {name}"
+        cv2.putText(frame, label, (16, 34), cv2.FONT_HERSHEY_SIMPLEX,
+                    0.8, (0, 255, 0), 2, cv2.LINE_AA)
+        Path("debug").mkdir(exist_ok=True)
+        Frame_Handler.save_frame(
+            frame,
+            f"debug/attack_{self._debug_attack_step:02d}_{name}.png",
+        )
+        Path("debug/attack_flow.log").open("a", encoding="utf-8").write(
+            label + "\n"
+        )
     
     # ============================================================
     # 📱 Screen Interaction
@@ -41,9 +65,13 @@ class Attacker:
 
     def start_normal_attack(self, timeout=60):
         import time
-        
+
+        self._debug_attack_step = 0
+        self._debug_stage("01_before_attack")
+
         # Click attack
         Input_Handler.click(0.07, 0.9)
+        self._debug_stage("02_attack_menu")
         
         # Find a match
         def locate_find_a_match():
@@ -57,20 +85,29 @@ class Attacker:
         if not click_with_timeout(
             locate_find_a_match,
             timeout=5
-        ): return False
+        ):
+            self._debug_stage("03_find_match_not_found")
+            return False
+        self._debug_stage("03_find_match")
         
         # Confirm attack
         if not click_with_timeout(
             lambda: Frame_Handler.locate(self.assets["confirm_attack"], thresh=0.9),
             timeout=5
-        ): return False
+        ):
+            self._debug_stage("04_confirm_not_found")
+            return False
+        self._debug_stage("04_confirmed")
         
         # Wait until "end battle" button is found
         start_time = time.time()
         while time.time() - start_time < timeout:
             x, y = Frame_Handler.locate(self.assets["end_battle"], thresh=0.9)
-            if x is not None and y is not None: return True
+            if x is not None and y is not None:
+                self._debug_stage("05_battle_started")
+                return True
             time.sleep(0.1)
+        self._debug_stage("05_battle_timeout")
         return False
     
     def start_builder_attack(self, timeout=60):
@@ -247,7 +284,8 @@ class Attacker:
     
     def complete_normal_attack(self, restart=True, exclude_clan_troops=False):
         import time, numpy as np
-        
+
+        self._debug_stage("06_battle_before_troops")
         Input_Handler.zoom(dir="out")
         Input_Handler.swipe_up()
         
@@ -259,6 +297,8 @@ class Attacker:
             frame = Frame_Handler.get_frame_section(0.0, 0.82, 1.0, 1.0, grayscale=False)
             # Find troops to deploy
             card_centers, card_boundaries, card_types, card_counts, type_gaps_seen = self.detect_troop_positions(frame, clip_left=last_card_left, type_gaps_seen=type_gaps_seen, return_boundaries=True, return_types=True, return_counts=True)
+
+            self._debug_stage(f"07_troop_cards_{total_slots_seen}")
             
             if len(card_centers) == 0: break
 
@@ -275,6 +315,7 @@ class Attacker:
             # Deploy troops up until the last one visible
             total_slots_seen += len(card_centers) - 1
             self.deploy_troops(card_centers[:-1], available_slots[:-1], card_types[:-1], card_counts[:-1])
+            self._debug_stage(f"08_deployed_{total_slots_seen}")
             # Scroll over and look for the new position of the last card
             last_card_frame = frame[:, int(card_boundaries[-2] * frame.shape[1]):int(card_boundaries[-1] * frame.shape[1])]
             Input_Handler.swipe_left(x1=card_centers[-1], x2=0.038, y=0.9, hold_end_time=500)
@@ -289,6 +330,7 @@ class Attacker:
                 break
         
         # Close and reopen CoC to auto complete battle
+        self._debug_stage("09_battle_complete")
         if restart:
             start_coc()
         else:

--- a/src/configs.template.py
+++ b/src/configs.template.py
@@ -133,7 +133,9 @@ ATTACK_BUILDER_BASE = True # can be overridden on desktop or web app
 ########################
 DEBUG = False
 DISABLE_DEVICE_SLEEP = True
-AUTO_START_BLUESTACKS = True
+EMULATOR_TYPE = "bluestacks" # "bluestacks" or "mumu"
+AUTO_START_EMULATOR = True
 WINDOW_DIMS = (1920, 1080) # width, height
 ADB_ABS_DIR = "" # absolute path to dir with adb executable, leave empty to use system PATH
 BLUESTACKS_BIN_PATH = "" # absolute path to Bluestacks executable, leave empty to use system defaults
+MUMU_BIN_PATH = "" # absolute path to MuMuManager.exe, leave empty to use system defaults

--- a/src/test.py
+++ b/src/test.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
     # bot.upgrader.home_lab_random_upgrade()
     # bot.upgrader.home_lab_specified_upgrade(HOME_LAB_UPGRADE_PRIORITY[0])
     # bot.upgrader.assign_builder_assistant()
+    # bot.attacker.start_normal_attack()
     # bot.attacker.run_home_base()
     # bot.attacker.complete_normal_attack(exclude_clan_troops=EXCLUDE_CLAN_TROOPS)
     # bot.attacker.complete_builder_attack()

--- a/src/test.py
+++ b/src/test.py
@@ -5,7 +5,7 @@ from utils import *
 from coc_bot import CoC_Bot
 
 if __name__ == "__main__":
-    configs.AUTO_START_BLUESTACKS = False
+    configs.AUTO_START_EMULATOR = False
     args = parse_args(debug=True, id="main")
     init_instance(args.id)
     bot = CoC_Bot()
@@ -21,7 +21,6 @@ if __name__ == "__main__":
     # bot.upgrader.home_lab_random_upgrade()
     # bot.upgrader.home_lab_specified_upgrade(HOME_LAB_UPGRADE_PRIORITY[0])
     # bot.upgrader.assign_builder_assistant()
-    # bot.attacker.start_normal_attack()
     # bot.attacker.run_home_base()
     # bot.attacker.complete_normal_attack(exclude_clan_troops=EXCLUDE_CLAN_TROOPS)
     # bot.attacker.complete_builder_attack()

--- a/src/utils.py
+++ b/src/utils.py
@@ -48,8 +48,9 @@ def init_instance(id):
     
     assert id in configs.INSTANCE_IDS, f"Invalid instance ID. Must be one of: {configs.INSTANCE_IDS}"
     INSTANCE_ID = id
-    if configs.AUTO_START_BLUESTACKS: BlueStacks_Manager.init()
-    ADB_ADDRESS = BlueStacks_Manager.adb_address
+    emulator_manager = {"bluestacks": BlueStacks_Manager, "mumu": MuMu_Manager}[getattr(configs, "EMULATOR_TYPE", "bluestacks")]
+    if getattr(configs, "AUTO_START_EMULATOR", getattr(configs, "AUTO_START_BLUESTACKS", True)): emulator_manager.init()
+    ADB_ADDRESS = emulator_manager.adb_address
     if WEB_APP_URL != "":
         if "pythonanywhere.com" in WEB_APP_URL:
             Scheduler.add_job(extend_pythonanywhere_hosting, args=(configs.PA_USERNAME, configs.PA_PASSWORD), trigger="interval", hours=24)
@@ -864,6 +865,123 @@ class BlueStacks_Manager:
         cls.stop()
         cls.start()
 
+class MuMu_Manager:
+    """
+    Instance identity is resolved via MuMuManager.exe's own "name" field for each vmindex,
+    which must be renamed (in MuMu's multi-instance manager) to match the bot instance ID,
+    same convention as BlueStacks_Manager.internal_instance_name.
+    """
+
+    _vmindex = None
+    _adb_port = None
+    _manager_path = None
+
+    @classmethod
+    def init(cls):
+        Exit_Handler.register(cls.stop)
+        cls.restart()
+
+    @classproperty
+    def manager_path(cls):
+        if cls._manager_path is not None and Path(cls._manager_path).exists():
+            return cls._manager_path
+
+        bin_path = getattr(configs, "MUMU_BIN_PATH", "") or r"C:\Program Files\Netease\MuMuPlayer\nx_main\MuMuManager.exe"
+        if not Path(bin_path).exists():
+            bin_path = file_search("/", "MuMuManager.exe", ["netease", "mumu"])
+        assert bin_path is not None and Path(bin_path).exists(), f"MuMuManager.exe not found at {bin_path}"
+        cls._manager_path = bin_path
+        return cls._manager_path
+
+    @classmethod
+    def _run(cls, *args):
+        import subprocess, json
+        res = subprocess.run([cls.manager_path, *args], capture_output=True, text=True)
+        return json.loads(res.stdout) if res.stdout.strip() else {}
+
+    @classproperty
+    def vmindex(cls, instance_id=None):
+        if cls._vmindex is not None:
+            return cls._vmindex
+
+        instance_id = instance_id if instance_id is not None else INSTANCE_ID
+        info = cls._run("info", "--vmindex", "all")
+        for index, data in info.items():
+            if data.get("name") == instance_id:
+                cls._vmindex = index
+                break
+        else:
+            raise Exception(f"No MuMu instance named '{instance_id}' found. Rename it in MuMu's multi-instance manager to match INSTANCE_IDS.")
+
+        return cls._vmindex
+
+    @classproperty
+    def adb_port(cls):
+        info = cls._run("info", "--vmindex", cls.vmindex)
+        port = info.get("adb_port")
+        if port is not None:
+            cls._adb_port = str(port)
+        elif cls._adb_port is None:
+            # ponytail: MuMu only reports adb_port once the instance is running; before that,
+            # fall back to its default multi-instance port formula (base 16384, step 32/index).
+            # Upgrade path: verify this formula still holds if MuMu changes its port scheme.
+            cls._adb_port = str(16384 + 32 * int(cls.vmindex))
+        return cls._adb_port
+
+    @classproperty
+    def adb_address(cls):
+        return f"127.0.0.1:{cls.adb_port}"
+
+    @classmethod
+    def check(cls):
+        try:
+            ADB_Manager.connect_once(cls.adb_address)
+            return True
+        except (KeyboardInterrupt, SystemExit): raise
+        except: return False
+
+    @classmethod
+    def start(cls, timeout=60):
+        import time
+
+        if cls.check():
+            if configs.DEBUG: print("MuMu already running.")
+            return
+
+        cls._run("control", "--vmindex", cls.vmindex, "launch")
+
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if cls.check():
+                if configs.DEBUG: print("MuMu started.")
+                return
+            time.sleep(0.5)
+
+        raise Exception("MuMu failed to start.")
+
+    @classmethod
+    def stop(cls, timeout=60):
+        import time
+
+        if not cls.check():
+            if configs.DEBUG: print("MuMu stopped.")
+            return
+        cls._run("control", "--vmindex", cls.vmindex, "shutdown")
+
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if not cls.check():
+                if configs.DEBUG: print("MuMu stopped.")
+                return
+            time.sleep(0.5)
+
+        raise Exception("MuMu failed to stop.")
+
+    @classmethod
+    def restart(cls):
+        cls.stop()
+        cls.start()
+
 class Task_Handler:
     
     cache_valid = False
@@ -1150,14 +1268,24 @@ class ADB_Manager:
 
 class Input_Handler:
     @classmethod
+    def _to_raw(cls, x_frac, y_frac):
+        raw_w = int(ADB_Manager.minitouch_device.connection.max_x)
+        raw_h = int(ADB_Manager.minitouch_device.connection.max_y)
+        if raw_w >= raw_h:
+            return int(x_frac * raw_w), int(y_frac * raw_h)
+        # ponytail: device reports native-portrait touch axes while the display is
+        # landscape (WINDOW_DIMS) -- compensate for the OS's rotation between the
+        # raw touch device and the composited display (seen on MuMu). Assumes a
+        # 90deg CW rotation, the common case for phone-profile emulators; upgrade
+        # path: detect rotation direction if a 270deg case is ever seen.
+        return int(raw_w - y_frac * raw_w), int(x_frac * raw_h)
+
+    @classmethod
     def down(cls, x, y, pointer=0):
         from pyminitouch import CommandBuilder
         if x < 0: x = 1 + x
         if y < 0: y = 1 + y
-        MAX_X = int(ADB_Manager.minitouch_device.connection.max_x)
-        MAX_Y = int(ADB_Manager.minitouch_device.connection.max_y)
-        x = int(x * MAX_X)
-        y = int(y * MAX_Y)
+        x, y = cls._to_raw(x, y)
         builder = CommandBuilder()
         builder.down(pointer, x, y, 100)
         builder.publish(ADB_Manager.minitouch_device.connection)
@@ -1175,10 +1303,10 @@ class Input_Handler:
         from pyminitouch import CommandBuilder
         if x < 0: x = 1 + x
         if y < 0: y = 1 + y
-        MAX_X = int(ADB_Manager.minitouch_device.connection.max_x)
-        MAX_Y = int(ADB_Manager.minitouch_device.connection.max_y)
-        x = int(x * MAX_X)
-        y = int(y * MAX_Y)
+        x_norm, y_norm = x, y
+        x, y = cls._to_raw(x, y)
+        if configs.DEBUG:
+            Frame_Handler.debug_click(x_norm, y_norm, x, y)
         builder = CommandBuilder()
         for _ in range(n):
             builder.down(pointer, x, y, 100)
@@ -1193,30 +1321,23 @@ class Input_Handler:
 
     @classmethod
     def multi_click(cls, x1, y1, x2, y2, duration=0):
-        MAX_X = int(ADB_Manager.minitouch_device.connection.max_x)
-        MAX_Y = int(ADB_Manager.minitouch_device.connection.max_y)
-        ADB_Manager.minitouch_device.tap([(x1*MAX_X, y1*MAX_Y), (x2*MAX_X, y2*MAX_Y)], duration=duration)
+        ADB_Manager.minitouch_device.tap([cls._to_raw(x1, y1), cls._to_raw(x2, y2)], duration=duration)
 
     @classmethod
     def swipe(cls, x1, y1, x2, y2, duration=100, hold_end_time=0, inter_points=0, pointer=0):
         import time, numpy as np
         from pyminitouch import CommandBuilder
-        
+
         if x1 < 0: x1 = 1 + x1
         if y1 < 0: y1 = 1 + y1
         if x2 < 0: x2 = 1 + x2
         if y2 < 0: y2 = 1 + y2
-        
+
         builder = CommandBuilder()
-        
-        MAX_X = int(ADB_Manager.minitouch_device.connection.max_x)
-        MAX_Y = int(ADB_Manager.minitouch_device.connection.max_y)
-        
-        x1 = int(x1 * MAX_X)
-        y1 = int(y1 * MAX_Y)
-        x2 = int(x2 * MAX_X)
-        y2 = int(y2 * MAX_Y)
-        
+
+        x1, y1 = cls._to_raw(x1, y1)
+        x2, y2 = cls._to_raw(x2, y2)
+
         x_points = np.linspace(x1, x2, inter_points + 2, dtype=int)
         y_points = np.linspace(y1, y2, inter_points + 2, dtype=int)
         dt = duration / (inter_points + 1)
@@ -1252,14 +1373,11 @@ class Input_Handler:
         from pyminitouch import CommandBuilder
         
         builder = CommandBuilder()
-        
-        MAX_X = int(ADB_Manager.minitouch_device.connection.max_x)
-        MAX_Y = int(ADB_Manager.minitouch_device.connection.max_y)
-        
-        left_in = to_int_array((0.15 + 0.30*percent)*MAX_X, 0.5*MAX_Y)
-        left_out = to_int_array(0.15*MAX_X, 0.5*MAX_Y)
-        right_in = to_int_array((0.85 - 0.30*percent)*MAX_X, 0.5*MAX_Y)
-        right_out = to_int_array(0.85*MAX_X, 0.5*MAX_Y)
+
+        left_in = cls._to_raw(0.15 + 0.30*percent, 0.5)
+        left_out = cls._to_raw(0.15, 0.5)
+        right_in = cls._to_raw(0.85 - 0.30*percent, 0.5)
+        right_out = cls._to_raw(0.85, 0.5)
         
         start = [left_in, right_in] if dir=="in" else [left_out, right_out]
         end = [left_out, right_out] if dir=="in" else [left_in, right_in]
@@ -1278,6 +1396,50 @@ class Input_Handler:
 class Frame_Handler:
     pool = None
     cached_frame = None
+
+    @classmethod
+    def _debug_base_frame(cls):
+        """Return a color frame suitable for temporary debug annotations."""
+        import numpy as np
+
+        frame = cls.cached_frame
+        if frame is None:
+            frame = cls.get_frame(grayscale=False, use_cached=False)
+        frame = np.asarray(frame)
+        if len(frame.shape) == 2:
+            import cv2
+            frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2RGB)
+        return frame.copy()
+
+    @classmethod
+    def _save_debug_overlay(cls, frame, label="", filename="debug/click_overlay.png"):
+        import cv2
+        from pathlib import Path
+
+        Path("debug").mkdir(exist_ok=True)
+        if label:
+            cv2.putText(frame, label, (12, 28), cv2.FONT_HERSHEY_SIMPLEX,
+                        0.7, (255, 255, 0), 2, cv2.LINE_AA)
+        cls.save_frame(frame, filename)
+
+    @classmethod
+    def debug_click(cls, x_norm, y_norm, raw_x, raw_y):
+        """Draw the latest click and append its normalized/raw coordinates."""
+        from pathlib import Path
+        import cv2
+
+        frame = cls._debug_base_frame()
+        height, width = frame.shape[:2]
+        px, py = int(x_norm * width), int(y_norm * height)
+        cv2.drawMarker(frame, (px, py), (255, 0, 255), cv2.MARKER_CROSS,
+                       36, 3, cv2.LINE_AA)
+        cv2.circle(frame, (px, py), 14, (255, 0, 255), 3, cv2.LINE_AA)
+        label = f"CLICK norm=({x_norm:.3f},{y_norm:.3f}) raw=({raw_x},{raw_y})"
+        cv2.putText(frame, label, (px + 18, max(28, py - 18)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 0, 255), 2,
+                    cv2.LINE_AA)
+        cls._save_debug_overlay(frame)
+        Path("debug/clicks.log").open("a", encoding="utf-8").write(label + "\n")
     
     @classmethod
     def grayscale(cls, frame):
@@ -1369,6 +1531,17 @@ class Frame_Handler:
         res = cv2.matchTemplate(frame, template, cv2.TM_CCOEFF_NORMED)
         _, max_val, _, max_loc = cv2.minMaxLoc(res)
         if configs.DEBUG: print("locate confidence:", max_val)
+
+        if configs.DEBUG and frame.shape[:2] == tuple(reversed(WINDOW_DIMS)):
+            overlay = cls._debug_base_frame()
+            x_loc, y_loc = max_loc
+            cv2.rectangle(overlay, (x_loc, y_loc),
+                          (x_loc + w, y_loc + h), (0, 255, 255), 2)
+            cv2.putText(overlay, f"ROI conf={max_val:.3f}",
+                        (x_loc, max(24, y_loc - 8)),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 255), 2,
+                        cv2.LINE_AA)
+            cls._save_debug_overlay(overlay, filename="debug/roi_overlay.png")
         
         if return_all:
             ys, xs = np.where(res >= thresh)

--- a/src/utils.py
+++ b/src/utils.py
@@ -49,7 +49,7 @@ def init_instance(id):
     assert id in configs.INSTANCE_IDS, f"Invalid instance ID. Must be one of: {configs.INSTANCE_IDS}"
     INSTANCE_ID = id
     emulator_manager = {"bluestacks": BlueStacks_Manager, "mumu": MuMu_Manager}[getattr(configs, "EMULATOR_TYPE", "bluestacks")]
-    if getattr(configs, "AUTO_START_EMULATOR", getattr(configs, "AUTO_START_BLUESTACKS", True)): emulator_manager.init()
+    if getattr(configs, "AUTO_START_EMULATOR", True): emulator_manager.init()
     ADB_ADDRESS = emulator_manager.adb_address
     if WEB_APP_URL != "":
         if "pythonanywhere.com" in WEB_APP_URL:
@@ -878,6 +878,8 @@ class MuMu_Manager:
 
     @classmethod
     def init(cls):
+        if sys.platform == "darwin":
+            raise Exception("MuMu Player is not supported on macOS yet. Use BlueStacks instead.")
         Exit_Handler.register(cls.stop)
         cls.restart()
 
@@ -1273,9 +1275,10 @@ class Input_Handler:
         raw_h = int(ADB_Manager.minitouch_device.connection.max_y)
         if raw_w >= raw_h:
             return int(x_frac * raw_w), int(y_frac * raw_h)
-        # ponytail: device reports native-portrait touch axes while the display is
-        # landscape (WINDOW_DIMS) -- compensate for the OS's rotation between the
-        # raw touch device and the composited display (seen on MuMu). Assumes a
+        # ponytail: not a "can't be set to landscape" limitation -- the display is
+        # landscape (WINDOW_DIMS) same as any other emulator. MuMu's virtual touch
+        # device just reports raw axes in native-portrait order regardless of the
+        # display orientation, so we compensate for that rotation here. Assumes a
         # 90deg CW rotation, the common case for phone-profile emulators; upgrade
         # path: detect rotation direction if a 270deg case is ever seen.
         return int(raw_w - y_frac * raw_w), int(x_frac * raw_h)
@@ -1303,10 +1306,7 @@ class Input_Handler:
         from pyminitouch import CommandBuilder
         if x < 0: x = 1 + x
         if y < 0: y = 1 + y
-        x_norm, y_norm = x, y
         x, y = cls._to_raw(x, y)
-        if configs.DEBUG:
-            Frame_Handler.debug_click(x_norm, y_norm, x, y)
         builder = CommandBuilder()
         for _ in range(n):
             builder.down(pointer, x, y, 100)
@@ -1398,50 +1398,6 @@ class Frame_Handler:
     cached_frame = None
 
     @classmethod
-    def _debug_base_frame(cls):
-        """Return a color frame suitable for temporary debug annotations."""
-        import numpy as np
-
-        frame = cls.cached_frame
-        if frame is None:
-            frame = cls.get_frame(grayscale=False, use_cached=False)
-        frame = np.asarray(frame)
-        if len(frame.shape) == 2:
-            import cv2
-            frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2RGB)
-        return frame.copy()
-
-    @classmethod
-    def _save_debug_overlay(cls, frame, label="", filename="debug/click_overlay.png"):
-        import cv2
-        from pathlib import Path
-
-        Path("debug").mkdir(exist_ok=True)
-        if label:
-            cv2.putText(frame, label, (12, 28), cv2.FONT_HERSHEY_SIMPLEX,
-                        0.7, (255, 255, 0), 2, cv2.LINE_AA)
-        cls.save_frame(frame, filename)
-
-    @classmethod
-    def debug_click(cls, x_norm, y_norm, raw_x, raw_y):
-        """Draw the latest click and append its normalized/raw coordinates."""
-        from pathlib import Path
-        import cv2
-
-        frame = cls._debug_base_frame()
-        height, width = frame.shape[:2]
-        px, py = int(x_norm * width), int(y_norm * height)
-        cv2.drawMarker(frame, (px, py), (255, 0, 255), cv2.MARKER_CROSS,
-                       36, 3, cv2.LINE_AA)
-        cv2.circle(frame, (px, py), 14, (255, 0, 255), 3, cv2.LINE_AA)
-        label = f"CLICK norm=({x_norm:.3f},{y_norm:.3f}) raw=({raw_x},{raw_y})"
-        cv2.putText(frame, label, (px + 18, max(28, py - 18)),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 0, 255), 2,
-                    cv2.LINE_AA)
-        cls._save_debug_overlay(frame)
-        Path("debug/clicks.log").open("a", encoding="utf-8").write(label + "\n")
-    
-    @classmethod
     def grayscale(cls, frame):
         import cv2
         if len(frame.shape) == 3:
@@ -1532,17 +1488,6 @@ class Frame_Handler:
         _, max_val, _, max_loc = cv2.minMaxLoc(res)
         if configs.DEBUG: print("locate confidence:", max_val)
 
-        if configs.DEBUG and frame.shape[:2] == tuple(reversed(WINDOW_DIMS)):
-            overlay = cls._debug_base_frame()
-            x_loc, y_loc = max_loc
-            cv2.rectangle(overlay, (x_loc, y_loc),
-                          (x_loc + w, y_loc + h), (0, 255, 255), 2)
-            cv2.putText(overlay, f"ROI conf={max_val:.3f}",
-                        (x_loc, max(24, y_loc - 8)),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 255), 2,
-                        cv2.LINE_AA)
-            cls._save_debug_overlay(overlay, filename="debug/roi_overlay.png")
-        
         if return_all:
             ys, xs = np.where(res >= thresh)
             results = []


### PR DESCRIPTION
## Summary
- Adds `MuMu_Manager`, mirroring `BlueStacks_Manager`, to launch/stop MuMu instances and resolve their ADB address via `MuMuManager.exe`
- New `EMULATOR_TYPE` config (`bluestacks` or `mumu`) selects which manager is used; `AUTO_START_EMULATOR` replaces `AUTO_START_BLUESTACKS`
- `Input_Handler` touch coordinates now go through a shared `_to_raw` helper, which also compensates for MuMu reporting portrait-native touch axes while the display is landscape
- Optional debug snapshotting (gated behind `DEBUG`) for the home-base attack flow and click overlays, to help diagnose deploy issues
- README updated with MuMu setup steps

## Test plan
- [ ] Run the bot against a MuMu Player instance end-to-end (home base attack, builder base attack, start/stop)
- [ ] Confirm BlueStacks path still works unchanged (`EMULATOR_TYPE = "bluestacks"`)
- [ ] Verify touch coordinates land correctly on MuMu (taps/swipes/zoom)