### PR TITLE
Fix BlueStacks 5 ADB detection on Windows

### DIFF
--- a/scripts/adb.cmd
+++ b/scripts/adb.cmd
@@ -1,2 +1,0 @@
-@echo off
-"%ProgramFiles%\BlueStacks_nxt\HD-Adb.exe" %*

--- a/scripts/adb.cmd
+++ b/scripts/adb.cmd
@@ -1,0 +1,2 @@
+@echo off
+"%ProgramFiles%\BlueStacks_nxt\HD-Adb.exe" %*

--- a/src/utils.py
+++ b/src/utils.py
@@ -1601,12 +1601,9 @@ class Frame_Handler:
         if use_cached and cls.cached_frame is not None:
             frame = cls.cached_frame.copy()
         else:
-            if sys.platform == "win32" and getattr(configs, "EMULATOR_TYPE", "bluestacks") == "bluestacks":
-                frame = ADB_Manager.adbutils_device.screenshot()
-            else:
-                try: frame = ADB_Manager.adbutils_device.framebuffer() # faster than screenshot but potentially unstable
-                except (KeyboardInterrupt, SystemExit): raise
-                except: frame = ADB_Manager.adbutils_device.screenshot()
+            try: frame = ADB_Manager.adbutils_device.framebuffer() # faster than screenshot but potentially unstable
+            except (KeyboardInterrupt, SystemExit): raise
+            except: frame = ADB_Manager.adbutils_device.screenshot()
             frame = np.array(frame)[..., :3]
             frame = cv2.resize(frame, WINDOW_DIMS, interpolation=cv2.INTER_NEAREST)
             cls.cached_frame = frame.copy()

--- a/src/utils.py
+++ b/src/utils.py
@@ -851,47 +851,34 @@ class BlueStacks_Manager(_Emulator_Manager):
     """
     
     _internal_instance_name = None
-    _mim_path = None
     _conf_path = None
     
     @classproperty
     def internal_instance_name(cls, instance_id=None):
-        import json, re
+        import re
         
         if cls._internal_instance_name is not None:
             return cls._internal_instance_name
         
         instance_id = instance_id if instance_id is not None else INSTANCE_ID
         
-        if cls._mim_path is None or not Path(cls._mim_path).exists():
+        if cls._conf_path is None or not Path(cls._conf_path).exists():
             if sys.platform == "darwin":
-                cls._mim_path = "/Users/Shared/Library/Application Support/BlueStacks/Engine/UserData/MimMetaData.json"
+                cls._conf_path = "/Users/Shared/Library/Application Support/BlueStacks/bluestacks.conf"
             elif sys.platform == "win32":
-                cls._mim_path = r"C:\ProgramData\BlueStacks_nxt\Engine\UserData\MimMetaData.json"
+                cls._conf_path = r"C:\ProgramData\BlueStacks_nxt\bluestacks.conf"
             else:
                 raise Exception("Unsupported OS")
+            if not Path(cls._conf_path).exists():
+                cls._conf_path = file_search("/", "bluestacks.conf", ["bluestacks"])
 
-        if cls._internal_instance_name is None and Path(cls._mim_path).exists():
-            mim_data = json.loads(Path(cls._mim_path).read_text())
-            instances = {instance['Name']: instance["InstanceName"] for instance in mim_data["Organization"]}
-            cls._internal_instance_name = instances.get(instance_id, None)
-
-        # Newer BlueStacks versions store the display name in bluestacks.conf
-        # instead of generating MimMetaData.json.
-        if cls._internal_instance_name is None:
-            conf_path = cls._conf_path
-            if conf_path is None:
-                if sys.platform == "darwin":
-                    conf_path = "/Users/Shared/Library/Application Support/BlueStacks/bluestacks.conf"
-                elif sys.platform == "win32":
-                    conf_path = r"C:\ProgramData\BlueStacks_nxt\bluestacks.conf"
-            if conf_path is not None and Path(conf_path).exists():
-                pattern = re.compile(r'^bst\.instance\.([^.]+)\.display_name="?(.*?)"?$')
-                for line in Path(conf_path).read_text().splitlines():
-                    match = pattern.match(line)
-                    if match and match.group(2) == instance_id:
-                        cls._internal_instance_name = match.group(1)
-                        break
+        if cls._conf_path is not None and Path(cls._conf_path).exists():
+            pattern = re.compile(r'^bst\.instance\.([^.]+)\.display_name="?(.*?)"?$')
+            for line in Path(cls._conf_path).read_text().splitlines():
+                match = pattern.match(line)
+                if match and match.group(2) == instance_id:
+                    cls._internal_instance_name = match.group(1)
+                    break
 
         if cls._internal_instance_name is None:
             raise RuntimeError(
@@ -1387,15 +1374,11 @@ class ADB_Manager:
         from pyminitouch import MNTDevice
         
         if addr is None: addr = ADB_ADDRESS
-        if ADB_ABS_DIR != "":
-            os.environ["PATH"] = ADB_ABS_DIR + os.pathsep + os.environ["PATH"]
-
+        if ADB_ABS_DIR != "": os.environ["PATH"] = ADB_ABS_DIR + os.pathsep + os.environ["PATH"]
         adb_executable = shutil.which("adb")
-        if ADB_ABS_DIR == "" and sys.platform == "win32" and getattr(configs, "EMULATOR_TYPE", "bluestacks") == "bluestacks":
-            wrapper = Path(__file__).parent.parent / "scripts" / "adb.cmd"
+        if sys.platform == "win32" and getattr(configs, "EMULATOR_TYPE", "bluestacks") == "bluestacks":
             bluestacks_adb = Path(os.environ.get("ProgramFiles", r"C:\Program Files")) / "BlueStacks_nxt" / "HD-Adb.exe"
-            if wrapper.exists() and bluestacks_adb.exists():
-                adb_executable = str(wrapper.resolve())
+            if bluestacks_adb.exists(): adb_executable = str(bluestacks_adb)
         if adb_executable is None:
             raise FileNotFoundError("ADB executable not found. Set ADB_ABS_DIR to its directory.")
         os.environ["ADBUTILS_ADB_PATH"] = adb_executable
@@ -1403,7 +1386,6 @@ class ADB_Manager:
         pyminitouch.config.ADB_EXECUTOR = adb_executable
         import pyminitouch.connection
         pyminitouch.connection._ADB = adb_executable
-
         if cls.is_connected(): return
         subprocess.run([adb_executable, "start-server"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         res = adbutils.adb.connect(addr)

--- a/src/utils.py
+++ b/src/utils.py
@@ -856,7 +856,7 @@ class BlueStacks_Manager(_Emulator_Manager):
     
     @classproperty
     def internal_instance_name(cls, instance_id=None):
-        import json
+        import json, re
         
         if cls._internal_instance_name is not None:
             return cls._internal_instance_name
@@ -870,17 +870,35 @@ class BlueStacks_Manager(_Emulator_Manager):
                 cls._mim_path = r"C:\ProgramData\BlueStacks_nxt\Engine\UserData\MimMetaData.json"
             else:
                 raise Exception("Unsupported OS")
-            if cls._mim_path is None or not Path(cls._mim_path).exists():
-                cls._mim_path = file_search("/", "MimMetaData.json", ["bluestacks"])
 
-        if cls._internal_instance_name is None and cls._mim_path is not None:
-            if cls._mim_path is not None and Path(cls._mim_path).exists():
-                mim_data = json.loads(Path(cls._mim_path).read_text())
-                instances = {instance['Name']: instance["InstanceName"] for instance in mim_data["Organization"]}
-                cls._internal_instance_name = instances.get(instance_id, None)
-            else:
-                if configs.DEBUG: print("MimMetaData.json not found, using default instance.")
-        
+        if cls._internal_instance_name is None and Path(cls._mim_path).exists():
+            mim_data = json.loads(Path(cls._mim_path).read_text())
+            instances = {instance['Name']: instance["InstanceName"] for instance in mim_data["Organization"]}
+            cls._internal_instance_name = instances.get(instance_id, None)
+
+        # Newer BlueStacks versions store the display name in bluestacks.conf
+        # instead of generating MimMetaData.json.
+        if cls._internal_instance_name is None:
+            conf_path = cls._conf_path
+            if conf_path is None:
+                if sys.platform == "darwin":
+                    conf_path = "/Users/Shared/Library/Application Support/BlueStacks/bluestacks.conf"
+                elif sys.platform == "win32":
+                    conf_path = r"C:\ProgramData\BlueStacks_nxt\bluestacks.conf"
+            if conf_path is not None and Path(conf_path).exists():
+                pattern = re.compile(r'^bst\.instance\.([^.]+)\.display_name="?(.*?)"?$')
+                for line in Path(conf_path).read_text().splitlines():
+                    match = pattern.match(line)
+                    if match and match.group(2) == instance_id:
+                        cls._internal_instance_name = match.group(1)
+                        break
+
+        if cls._internal_instance_name is None:
+            raise RuntimeError(
+                f"BlueStacks instance '{instance_id}' was not found. "
+                "Rename the emulator instance to match INSTANCE_IDS."
+            )
+
         return cls._internal_instance_name
     
     @classproperty
@@ -899,15 +917,17 @@ class BlueStacks_Manager(_Emulator_Manager):
                 cls._conf_path = file_search("/", "bluestacks.conf", ["bluestacks"])
 
         if cls._adb_port is None and cls._conf_path is not None:
-            if cls._conf_path is not None and Path(cls._conf_path).exists():
+            if Path(cls._conf_path).exists():
                 conf_data = Path(cls._conf_path).read_text()
                 for line in conf_data.splitlines():
                     if line.startswith(f"bst.instance.{cls.internal_instance_name}.adb_port"):
-                        cls._adb_port = line.split("=")[1].strip().replace('"', '')
+                        cls._adb_port = line.split("=", 1)[1].strip().replace('"', '')
                         break
-            else:
-                if configs.DEBUG: print("bluestacks.conf not found, using default adb port.")
-                cls._adb_port = "5555"
+
+        if cls._adb_port is None:
+            raise RuntimeError(
+                f"ADB port for BlueStacks instance '{cls.internal_instance_name}' was not found."
+            )
 
         return cls._adb_port
 
@@ -1362,17 +1382,33 @@ class ADB_Manager:
 
     @classmethod
     def connect_once(cls, addr=None):
-        import subprocess, adbutils, os
+        import subprocess, adbutils, os, shutil
         import uiautomator2 as u2
         from pyminitouch import MNTDevice
         
         if addr is None: addr = ADB_ADDRESS
-        if ADB_ABS_DIR != "": os.environ["PATH"] = ADB_ABS_DIR + os.pathsep + os.environ["PATH"]
+        if ADB_ABS_DIR != "":
+            os.environ["PATH"] = ADB_ABS_DIR + os.pathsep + os.environ["PATH"]
+
+        adb_executable = shutil.which("adb")
+        if ADB_ABS_DIR == "" and sys.platform == "win32" and getattr(configs, "EMULATOR_TYPE", "bluestacks") == "bluestacks":
+            wrapper = Path(__file__).parent.parent / "scripts" / "adb.cmd"
+            bluestacks_adb = Path(os.environ.get("ProgramFiles", r"C:\Program Files")) / "BlueStacks_nxt" / "HD-Adb.exe"
+            if wrapper.exists() and bluestacks_adb.exists():
+                adb_executable = str(wrapper.resolve())
+        if adb_executable is None:
+            raise FileNotFoundError("ADB executable not found. Set ADB_ABS_DIR to its directory.")
+        os.environ["ADBUTILS_ADB_PATH"] = adb_executable
+        import pyminitouch.config
+        pyminitouch.config.ADB_EXECUTOR = adb_executable
+        import pyminitouch.connection
+        pyminitouch.connection._ADB = adb_executable
+
         if cls.is_connected(): return
-        subprocess.run(["adb", "start-server"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run([adb_executable, "start-server"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         res = adbutils.adb.connect(addr)
         if "connected" not in res:
-            subprocess.run(["adb", "kill-server"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run([adb_executable, "kill-server"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             raise Exception("Failed to connect to ADB.")
         devices = []
         try:
@@ -1383,7 +1419,7 @@ class ADB_Manager:
             Exit_Handler.register(d2.stop)
         except (KeyboardInterrupt, SystemExit): raise
         except:
-            subprocess.run(["adb", "kill-server"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run([adb_executable, "kill-server"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             raise Exception("Failed to get ADB device.")
         cls._adbutils_device, cls._minitouch_device, cls._uiautomator_device = devices
     
@@ -1583,9 +1619,12 @@ class Frame_Handler:
         if use_cached and cls.cached_frame is not None:
             frame = cls.cached_frame.copy()
         else:
-            try: frame = ADB_Manager.adbutils_device.framebuffer() # faster than screenshot but potentially unstable
-            except (KeyboardInterrupt, SystemExit): raise
-            except: frame = ADB_Manager.adbutils_device.screenshot()
+            if sys.platform == "win32" and getattr(configs, "EMULATOR_TYPE", "bluestacks") == "bluestacks":
+                frame = ADB_Manager.adbutils_device.screenshot()
+            else:
+                try: frame = ADB_Manager.adbutils_device.framebuffer() # faster than screenshot but potentially unstable
+                except (KeyboardInterrupt, SystemExit): raise
+                except: frame = ADB_Manager.adbutils_device.screenshot()
             frame = np.array(frame)[..., :3]
             frame = cv2.resize(frame, WINDOW_DIMS, interpolation=cv2.INTER_NEAREST)
             cls.cached_frame = frame.copy()


### PR DESCRIPTION
## Summary

Fix BlueStacks 5 ADB connection issues on Windows.

## Changes

- Support BlueStacks instances defined in `bluestacks.conf`.
- Read the correct ADB port for the selected instance.
- Automatically detect BlueStacks' `HD-Adb.exe`.
- Configure ADB-dependent libraries to use the detected executable.
- Use stable screenshot capture with BlueStacks on Windows.
- Add an ADB wrapper for standard BlueStacks installations.

## Testing

Tested on Windows 11 with BlueStacks 5. The emulator starts successfully, the correct instance and ADB port are detected, and the bot connects to ADB successfully.

Related to #26